### PR TITLE
update to OpenRefine 3.1 and some basic enhancements by psychemedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/betatim/openrefineder/master)
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/betatim/openrefineder/master?urlpath=%2Fopenrefine) (launch open refine)
-
 Small demo of using [OpenRefine](http://openrefine.org/) on binder.
 Still under 👷🚧🏗!
 
-
 # Starting OpenRefine in a binder
+
+## Quickstart
+
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/betatim/openrefineder/master?urlpath=%2Fopenrefine) (launch binder with option urlpath=/openrefine)
+
+## From JupyterLab home screen
 
 To access OpenRefine wait for the binder to launch. Then click
 "New -> OpenRefine session" on the right hand side of the screen.

--- a/nbopenrefineproxy/handlers.py
+++ b/nbopenrefineproxy/handlers.py
@@ -36,6 +36,6 @@ class AddSlashHandler(IPythonHandler):
 def setup_handlers(web_app):
     web_app.add_handlers('.*', [
         (ujoin(web_app.settings['base_url'], 'openrefine/(.*)'),
-         OpenRefineProxyHandler, dict(state={})),
+         OpenRefineProxyHandler, dict(state={'port':3333})),
         (ujoin(web_app.settings['base_url'], 'openrefine'), AddSlashHandler)
         ])

--- a/nbopenrefineproxy/handlers.py
+++ b/nbopenrefineproxy/handlers.py
@@ -12,7 +12,7 @@ class OpenRefineProxyHandler(SuperviseAndProxyHandler):
     name = 'OpenRefine'
 
     def get_cmd(self):
-        cmd = ['openrefine-2.8/refine',
+        cmd = ['openrefine-3.1/refine',
                '-p', str(self.port)
                ]
         return cmd

--- a/nbopenrefineproxy/handlers.py
+++ b/nbopenrefineproxy/handlers.py
@@ -12,7 +12,7 @@ class OpenRefineProxyHandler(SuperviseAndProxyHandler):
     name = 'OpenRefine'
 
     def get_cmd(self):
-        path = os.path.join(os.environ['HOME'], 'openrefine')
+        path = os.path.join(os.environ['HOME'], 'openrefine-workspace')
         os.makedirs(path, exist_ok=True)
         cmd = ['openrefine-3.1/refine',
                '-p', str(self.port),

--- a/nbopenrefineproxy/handlers.py
+++ b/nbopenrefineproxy/handlers.py
@@ -6,14 +6,17 @@ from notebook.base.handlers import IPythonHandler
 from notebook.utils import url_path_join as ujoin
 
 from nbserverproxy.handlers import SuperviseAndProxyHandler
-
+import os
 
 class OpenRefineProxyHandler(SuperviseAndProxyHandler):
     name = 'OpenRefine'
 
     def get_cmd(self):
+        path = os.path.join(os.environ['HOME'], 'openrefine')
+        os.makedirs(path, exist_ok=True)
         cmd = ['openrefine-3.1/refine',
-               '-p', str(self.port)
+               '-p', str(self.port),
+               '-d',path
                ]
         return cmd
 

--- a/postBuild
+++ b/postBuild
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-wget -q -O openrefine-2.8.tar.gz https://github.com/OpenRefine/OpenRefine/releases/download/2.8/openrefine-linux-2.8.tar.gz
-tar xzf openrefine-2.8.tar.gz
+wget -q -O openrefine-3.1.tar.gz https://github.com/OpenRefine/OpenRefine/releases/download/3.1/openrefine-linux-3.1.tar.gz
+tar xzf openrefine-3.1.tar.gz
 
 pip install https://github.com/betatim/nbserverproxy/archive/master.zip
 jupyter serverextension enable --py nbserverproxy

--- a/postBuild
+++ b/postBuild
@@ -3,6 +3,7 @@ set -e
 
 wget -q -O openrefine-3.1.tar.gz https://github.com/OpenRefine/OpenRefine/releases/download/3.1/openrefine-linux-3.1.tar.gz
 tar xzf openrefine-3.1.tar.gz
+rm openrefine-3.1.tar.gz
 
 pip install https://github.com/betatim/nbserverproxy/archive/master.zip
 jupyter serverextension enable --py nbserverproxy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/dbutlerdb/refine-client-py


### PR DESCRIPTION
I would like to suggest some improvements from @psychemedia (and some minor additions by myself) for the main repo:
* update to OpenRefine 3.1 (current stable version)
* set OpenRefine workspace dir relative to $HOME
* set OpenRefine port to 3333
* add python client for OpenRefine in requirements.txt
* remove tar file after extracting
* explain different launch options in README.md

There is also a demo notebook in https://github.com/ouseful-PR/openrefineder. It works with the suggested changes in this pull request but I think that it is still work in progress.