### PR TITLE
Enable JupyterLab launcher

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -21,3 +21,6 @@ python -m bash_kernel.install
 # move traitlet config in one of the Jupyter config directories
 mkdir -p $HOME/.jupyter/
 mv $HOME/binder/jupyter_notebook_config.py $HOME/.jupyter/
+
+# Enable JupyterLab launcher
+jupyter labextension install @jupyterlab/server-proxy


### PR DESCRIPTION
I figured out that the extension `@jupyter/server-proxy` is newer than `jupyterlab-server-proxy`. This makes the build work.

https://mybinder.org/v2/gh/felixlohmeier/openrefineder/jupyterlab?urlpath=lab

![Screenshot_2021-01-26_JupyterLab](https://user-images.githubusercontent.com/2117205/105831301-d3697800-5fc6-11eb-8fcf-c4bb867afb31.png)
